### PR TITLE
Fix "Add Witness UTXO" button action

### DIFF
--- a/src/main/scala/org/psbttoolkit/gui/psbts/PSBTButtons.scala
+++ b/src/main/scala/org/psbttoolkit/gui/psbts/PSBTButtons.scala
@@ -32,7 +32,7 @@ class PSBTButtons(model: PSBTsPaneModel) {
   }
 
   private val addWitnessUTXO: Button = new Button("Add Witness UTXO") {
-    onAction = _ => model.addNonWitnessUTXO()
+    onAction = _ => model.addWitnessUTXO()
   }
 
   private val addInputRedeemScript: Button = new Button(


### PR DESCRIPTION
Awesome tool, very useful!

Found a bug while playing around with it. The "Add Witness UTXO" button invokes the same action as the "Add Non-Witness UTXO" button.
